### PR TITLE
Use exec_script_allowlist in //llvm/utils/gn/.gn

### DIFF
--- a/llvm/utils/gn/.gn
+++ b/llvm/utils/gn/.gn
@@ -6,7 +6,7 @@ buildconfig = "//llvm/utils/gn/build/BUILDCONFIG.gn"
 
 # Disallow all calls to exec_script. We should be very conservative about
 # whitelisting things here.
-exec_script_whitelist = []
+exec_script_allowlist = []
 
 # Execute action() targets using Python 3.
 script_executable = "python3"


### PR DESCRIPTION
Use exec_script_allowlist in //llvm/utils/gn/.gn

GN is moving to use exec_script_allowlist instead of exec_script_whitelist everywhere.

See crbug.com/389986807